### PR TITLE
Support relative paths on 3.3 Cordova in Android

### DIFF
--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
+import org.apache.cordova.CordovaResourceApi;
 
 public class FileOpener2 extends CordovaPlugin {
 
@@ -72,7 +73,12 @@ public class FileOpener2 extends CordovaPlugin {
 	public void onDestroy() {
 	}
 
-	private boolean _open(String fileName, String contentType, CallbackContext callbackContext) throws JSONException {
+	private boolean _open(String fileArg, String contentType, CallbackContext callbackContext) throws JSONException {
+
+        CordovaResourceApi resourceApi = webView.getResourceApi();
+
+        Uri fileUri = resourceApi.remapUri(Uri.parse(fileArg));
+        String fileName = org.apache.cordova.FileHelper.stripFileProtocol(fileUri.toString());
 
 		File file = new File(fileName);
 


### PR DESCRIPTION
Hi, this change adds support for opening app relative paths, which is required in Cordova 3.5.

```
  cordova.plugins.fileOpener2.open(
      fileEntry.toURL(),
      'application/pdf',
      {
        error : function(errorObj) {
          console.log('Error status: ' + errorObj.status + ' - Error message: ' + errorObj.message);
        },
        success : function () {
          console.log('file opened successfully');
        }
      }
    );
```
