### PR TITLE
fix URL encoding errors for `file:///` URLs on iOS

### DIFF
--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -42,14 +42,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         NSArray *dotParts = [path componentsSeparatedByString:@"."];
         NSString *fileExt = [dotParts lastObject];
 
-        NSString *uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+        uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
     }
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        //NSLog(@"path %@, uti:%@", path, uti);
         NSURL *fileURL = [NSURL fileURLWithPath:path];
         
         localFile = fileURL.path;
+        
+        NSLog(@"looking for file at %@", fileURL);
+        NSFileManager *fm = [NSFileManager defaultManager];
+        if(![fm fileExistsAtPath:localFile]) {
+            NSLog(@"couldn't find file!");
+        } else {
+            NSLog(@"file located, handing off to UIDocumentInteractionController");
+        }
 
         self.controller = [UIDocumentInteractionController  interactionControllerWithURL:fileURL];
         self.controller.delegate = self;
@@ -57,7 +64,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         CGRect rect = CGRectMake(0, 0, 1000.0f, 150.0f);
         CDVPluginResult* pluginResult = nil;
-        BOOL wasOpened = [docController presentOptionsMenuFromRect:rect inView:cont.view animated:NO];
+        BOOL wasOpened = [self.controller presentOptionsMenuFromRect:rect inView:cont.view animated:NO];
 
         if(wasOpened) {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @""];

--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -27,57 +27,47 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #import <MobileCoreServices/MobileCoreServices.h>
 
 @implementation FileOpener2
-@synthesize controller = docController;
 
 - (void) open: (CDVInvokedUrlCommand*)command {
 
-    NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    //NSString *uti = [command.arguments objectAtIndex:1];
+    NSString *path = [command.arguments objectAtIndex:0];
+    NSString *uti = nil;
+    if (command.arguments.count > 1) {
+        uti = [command.arguments objectAtIndex:1];
+    }
 
     CDVViewController* cont = (CDVViewController*)[ super viewController ];
 
-    NSArray *dotParts = [path componentsSeparatedByString:@"."];
-    NSString *fileExt = [dotParts lastObject];
-	//NSString *fileExt = [[dotparts lastObject] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    if (!uti) {
+        NSArray *dotParts = [path componentsSeparatedByString:@"."];
+        NSString *fileExt = [dotParts lastObject];
 
-	NSString *uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+        NSString *uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+    }
 
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         //NSLog(@"path %@, uti:%@", path, uti);
-        NSURL *fileURL = nil;
-
-        //fileURL = [NSURL URLWithString:path];
-        fileURL = [NSURL fileURLWithPath:path];
+        NSURL *fileURL = [NSURL fileURLWithPath:path];
         
         localFile = fileURL.path;
 
-        dispatch_async(dispatch_get_main_queue(), ^{
+        self.controller = [UIDocumentInteractionController  interactionControllerWithURL:fileURL];
+        self.controller.delegate = self;
+        self.controller.UTI = uti;
 
-            docController = [UIDocumentInteractionController  interactionControllerWithURL:fileURL];
-            docController.delegate = self;
-            docController.UTI = uti;
+        CGRect rect = CGRectMake(0, 0, 1000.0f, 150.0f);
+        CDVPluginResult* pluginResult = nil;
+        BOOL wasOpened = [docController presentOptionsMenuFromRect:rect inView:cont.view animated:NO];
 
-            CGRect rect = CGRectMake(0, 0, 1000.0f, 150.0f);
-            CDVPluginResult* pluginResult = nil;
-            BOOL wasOpened = [docController presentOptionsMenuFromRect:rect inView:cont.view animated:NO];
-            //presentOptionsMenuFromRect
-            //presentOpenInMenuFromRect
-
-            if(wasOpened) {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @""];
-                //NSLog(@"Success");
-            } else {
-                NSDictionary *jsonObj = [ [NSDictionary alloc]
-                                         initWithObjectsAndKeys :
-                                         @"9", @"status",
-                                         @"Could not handle UTI", @"message",
-                                         nil
-                                         ];
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:jsonObj];
-                //NSLog(@"Could not handle UTI");
-            }
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-        });
+        if(wasOpened) {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @""];
+        } else {
+            NSDictionary *jsonObj = @{@"status" : @"9",
+                                      @"message" : @"Could not handle UTI"};
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                         messageAsDictionary:jsonObj];
+        }
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     });
 }
 

--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -52,8 +52,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         if(![fm fileExistsAtPath:localFile]) {
             NSDictionary *jsonObj = @{@"status" : @"9",
                                       @"message" : @"File does not exist"};
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                         messageAsDictionary:jsonObj];
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                          messageAsDictionary:jsonObj];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             return;
         }
 


### PR DESCRIPTION
We did some work with an iOS developer to fix issue #14, so URLs in standard format may be passed to fileOpener2.open without additional encoding/decoding steps.

Caveats:

* If your application was previously working around this bug with extra `decodeURI` operation, you'll have to remove that work-around when upgrading to this fixed version.
* The iOS code only deals with URLs, never with File objects or non-URL filesystem paths. I've only tested with `file://` URLs (as that's what `cordova.file.cacheDirectory` returns on my platform), I don't know if or when `cdvfile://` comes in to play.