### PR TITLE
Added support for Windows. WP8 file location change

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,11 +39,19 @@
 
 	<!-- WP8 -->
 	<platform name="wp8">
-	<config-file target="config.xml" parent="/*">
-	  <feature name="FileOpener2">
-		<param name="wp-package" value="FileOpener2" />
-	  </feature>
-	</config-file>
-	<source-file src="src/wp8/FileOpener2.cs" />
+		<config-file target="config.xml" parent="/*">
+		  <feature name="FileOpener2">
+			<param name="wp-package" value="FileOpener2" />
+		  </feature>
+		</config-file>
+		<source-file src="src/wp8/FileOpener2.cs" />
 	</platform>
+	
+
+	 <!-- windows -->
+    <platform name="windows">
+        <js-module src="src/windows/fileOpener2Proxy.js" name="fileOpener2Proxy">
+            <merges target="" />
+        </js-module>
+    </platform>
 </plugin>

--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -1,0 +1,26 @@
+
+	var cordova = require('cordova'),
+		fileOpener2 = require('./FileOpener2');
+
+	module.exports = {
+
+	    open: function (successCallback, errorCallback, args) {
+	        Windows.Storage.StorageFile.getFileFromPathAsync(args[0]).then(function (file) {
+	            var options = new Windows.System.LauncherOptions();
+	            options.displayApplicationPicker = true;
+
+	            Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
+	                if (success) {
+	                    successCallback();
+	                } else {
+	                    errorCallback();
+	                }
+	            });
+
+	        });
+		}
+		
+	};
+
+	require("cordova/exec/proxy").add("FileOpener2", module.exports);
+

--- a/src/wp8/FileOpener2.cs
+++ b/src/wp8/FileOpener2.cs
@@ -17,16 +17,13 @@ namespace WPCordovaClassLib.Cordova.Commands
         public async void open(string options)
         {
             string[] args = JSON.JsonHelper.Deserialize<string[]>(options);
-            var fileName = System.IO.Path.GetFileName(args[0]);
+
             string aliasCurrentCommandCallbackId = args[2];
 
             try
             {
-                // Access isolated storage.
-                StorageFolder local = Windows.Storage.ApplicationData.Current.LocalFolder;
-
-                // Access the file.
-                StorageFile file = await local.GetFileAsync(fileName);
+                // Get the file.
+                StorageFile file = await Windows.Storage.StorageFile.GetFileFromPathAsync(args[0]);
 
                 // Launch the bug query file.
                 await Windows.System.Launcher.LaunchFileAsync(file);


### PR DESCRIPTION
Added support for Windows.  On windows devices you are prompted as to which application you want to use to open the file.
Updated wp8 so that file can be on device, rather than only in local storage folder.

Usage for windows is exactly the same as other platforms, simply call something like

    cordova.plugins.fileOpener2.open(
        'ebook1.pdf', 
        'application/pdf'
    );

Although the second parameter is kind of pointless as you can chose the application to use anyway.  But i have used it on all platforms, and works fine