### PR TITLE
Option for adding bounds (useful on the iPad)

### DIFF
--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -34,6 +34,17 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     //NSString *uti = [command.arguments objectAtIndex:1];
 
+    CGRect bounds;
+    if (3 == [command.arguments count]) {
+        NSArray *boundsValues = [command.arguments objectAtIndex: 2];
+        bounds = CGRectMake([[boundsValues objectAtIndex:0] floatValue],
+                      [[boundsValues objectAtIndex:1] floatValue],
+                      [[boundsValues objectAtIndex:2] floatValue],
+                      [[boundsValues objectAtIndex:3] floatValue]);
+    } else {
+        bounds = CGRectMake(0, 0, 1000.0f, 150.0f);
+    }
+
     CDVViewController* cont = (CDVViewController*)[ super viewController ];
 
     NSArray *dotParts = [path componentsSeparatedByString:@"."];
@@ -57,9 +68,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             docController.delegate = self;
             docController.UTI = uti;
 
-            CGRect rect = CGRectMake(0, 0, 1000.0f, 150.0f);
             CDVPluginResult* pluginResult = nil;
-            BOOL wasOpened = [docController presentOptionsMenuFromRect:rect inView:cont.view animated:NO];
+            BOOL wasOpened = [docController presentOptionsMenuFromRect:bounds inView:cont.view animated:NO];
             //presentOptionsMenuFromRect
             //presentOpenInMenuFromRect
 

--- a/www/plugins.FileOpener2.js
+++ b/www/plugins.FileOpener2.js
@@ -31,6 +31,12 @@ FileOpener2.prototype.open = function (fileName, contentType, callbackContext) {
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType]);
 };
 
+FileOpener2.prototype.openIOS = function (fileName, contentType, bounds, callbackContext) {
+    callbackContext = callbackContext || {};
+    bounds = bounds || [0, 0, 1000 , 150];
+    exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, bounds]);
+};
+
 FileOpener2.prototype.uninstall = function (packageId, callbackContext) {
     callbackContext = callbackContext || {};
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'uninstall', [packageId]);


### PR DESCRIPTION
I added a new method `openIOS` that allows specifying the bounds for the UIDocumentInteractionController.
On the iPad the UIDocumentInteractionController looks like a modal box with an arrow pointing to the CGRect and that was by default some random value: (0, 0, 1000, 150).
