### PR TITLE
Windows: Add support for URI schemes

### DIFF
--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -2,13 +2,51 @@
 	var cordova = require('cordova'),
 		fileOpener2 = require('./FileOpener2');
 
+	var schemes = [
+        { protocol: 'ms-app', getFile: getFileFromApplicationUri },
+        { protocol: 'file:///', getFile: getFileFromFileUri }
+	]
+
+	function getFileFromApplicationUri(uri) {
+	    var applicationUri = new Windows.Foundation.Uri(uri);
+
+	    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
+	}
+
+	function getFileFromFileUri(uri) {
+	    var path = Windows.Storage.ApplicationData.current.localFolder.path +
+                        uri.substr(8);
+
+	    return getFileFromNativePath(path);
+	}
+
+	function getFileFromNativePath(path) {
+	    var nativePath = path.split("/").join("\\");
+
+	    return Windows.Storage.StorageFile.getFileFromPathAsync(nativePath);
+	}
+
+	function getFileLoaderForScheme(path) {
+	    var fileLoader = getFileFromNativePath;
+
+	    schemes.some(function (scheme) {
+	        return path.indexOf(scheme.protocol) === 0 ? ((fileLoader = scheme.getFile), true) : false;
+	    });
+
+	    return fileLoader;
+	}
+
 	module.exports = {
 
 	    open: function (successCallback, errorCallback, args) {
-	        Windows.Storage.StorageFile.getFileFromPathAsync(args[0]).then(function (file) {
-	            var options = new Windows.System.LauncherOptions();
-	            options.displayApplicationPicker = true;
+	        var path = args[0];
+	        
+	        var getFile = getFileLoaderForScheme(path);
 
+	        getFile(path).then(function (file) {
+	            var options = new Windows.System.LauncherOptions();	           
+	            options.displayApplicationPicker = true;
+				
 	            Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
 	                if (success) {
 	                    successCallback();
@@ -17,6 +55,8 @@
 	                }
 	            });
 
+	        }, function (errror) {
+	            console.log("Error abriendo el archivo");
 	        });
 		}
 		


### PR DESCRIPTION
I have added support for using URI schemes in windows platforms, like *ms-appdata:///* or *ms-appx:///*. See: [Uri Schemes on MSDN](https://msdn.microsoft.com/en-us/library/windows/apps/jj655406.aspx)

When using this plugin standalone the use of URIs could be thinked as totally optional, however when used in conbination with other common cordova plugins, like **cordova-plugin-file-transfer** or **cordova-plugin-file**, the use of URIs becomes much needed on windows, as those plugins fully leverage URI Schemes when working with file storage.

The code here adds some helper functions to call the right windows apis for opening files, based on the scheme used. 

As a bonus, it also handles *file:///* schemes, (that are not allowed in windows) and transforms them to local native paths, like cordova-plugin-file-transfer does.

 