### PR TITLE
Windows: Use default application instead of showing app chooser

### DIFF
--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -6,8 +6,7 @@
 
 	    open: function (successCallback, errorCallback, args) {
 	        Windows.Storage.StorageFile.getFileFromPathAsync(args[0]).then(function (file) {
-	            var options = new Windows.System.LauncherOptions();
-	            options.displayApplicationPicker = true;
+	            var options = new Windows.System.LauncherOptions();	            
 
 	            Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
 	                if (success) {


### PR DESCRIPTION
The current code, forces to choose always an app when opening files. This is very uncommon, by default, the associated app should be opened without user interaction.

The problem lies on passing *displayApplicationPicker = true* to **Windows.System.LauncherOptions**, forcing to show the application picker, regardless of default file associations. This option was designed to be used as a alternative open option for the user (Open With...), as can be read on [MSDN](https://msdn.microsoft.com/en-us/library/windows/apps/windows.system.launcheroptions.displayapplicationpicker):

>You should use the Open With dialog box when the user may want to select an app other than the default for a particular file. For example if your app allows the user to launch an image file, the default handler will likely be a viewer app. In some cases the user may want to edit the image instead of viewing it. Use the Open With option along with an alternative command in the AppBar or in a context menu to let the user bring up the Open With dialog and select the editor app in these types of scenarios.

This pull request fix that by removing options.displayApplicationPicker = true line from fileOpener2Proxy.js