### PR TITLE
Replaced plug-in ID by 'cordova-plugin-file-opener2'

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="io.github.pwlin.cordova.plugins.fileopener2" version="1.0.11">
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-file-opener2" version="1.0.11">
 
     <name>File Opener2</name>
     <description>A File Opener Plugin for Cordova. (The Original Version)</description>


### PR DESCRIPTION
Otherwise 'ionic state save' will store the old ID, which is not managed in Cordova's plug-in registry. Doing 'ionic state restore' at another place will therefore not re-install the plug-in and fail silently.