### PR TITLE
updated fix URL encoding errors on iOS

### DIFF
--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -27,57 +27,54 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #import <MobileCoreServices/MobileCoreServices.h>
 
 @implementation FileOpener2
-@synthesize controller = docController;
 
 - (void) open: (CDVInvokedUrlCommand*)command {
 
-    NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    //NSString *uti = [command.arguments objectAtIndex:1];
+    NSString *path = command.arguments[0];
+    NSString *uti = command.arguments[1];
+    if (!uti || (NSNull*)uti == [NSNull null]) {
+        NSArray *dotParts = [path componentsSeparatedByString:@"."];
+        NSString *fileExt = [dotParts lastObject];
+        
+        uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+    }
 
     CDVViewController* cont = (CDVViewController*)[ super viewController ];
 
-    NSArray *dotParts = [path componentsSeparatedByString:@"."];
-    NSString *fileExt = [dotParts lastObject];
-	//NSString *fileExt = [[dotparts lastObject] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-
-	NSString *uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
-
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        //NSLog(@"path %@, uti:%@", path, uti);
-        NSURL *fileURL = nil;
-
-        //fileURL = [NSURL URLWithString:path];
-        fileURL = [NSURL URLWithString:path];
-        //NSLog(@"%@",fileURL);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // TODO: test if this is a URI or a path
+        NSURL *fileURL = [NSURL URLWithString:path];
+        
         localFile = fileURL.path;
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-
-            docController = [UIDocumentInteractionController  interactionControllerWithURL:fileURL];
-            docController.delegate = self;
-            docController.UTI = uti;
-
-            CGRect rect = CGRectMake(0, 0, 1000.0f, 150.0f);
-            CDVPluginResult* pluginResult = nil;
-            BOOL wasOpened = [docController presentOptionsMenuFromRect:rect inView:cont.view animated:NO];
-            //presentOptionsMenuFromRect
-            //presentOpenInMenuFromRect
-
-            if(wasOpened) {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @""];
-                //NSLog(@"Success");
-            } else {
-                NSDictionary *jsonObj = [ [NSDictionary alloc]
-                                         initWithObjectsAndKeys :
-                                         @"9", @"status",
-                                         @"Could not handle UTI", @"message",
-                                         nil
-                                         ];
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:jsonObj];
-                //NSLog(@"Could not handle UTI");
-            }
+        
+        NSLog(@"looking for file at %@", fileURL);
+        NSFileManager *fm = [NSFileManager defaultManager];
+        if(![fm fileExistsAtPath:localFile]) {
+            NSDictionary *jsonObj = @{@"status" : @"9",
+                                      @"message" : @"File does not exist"};
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                          messageAsDictionary:jsonObj];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-        });
+            return;
+        }
+
+        self.controller = [UIDocumentInteractionController  interactionControllerWithURL:fileURL];
+        self.controller.delegate = self;
+        self.controller.UTI = uti;
+
+        CGRect rect = CGRectMake(0, 0, 1000.0f, 150.0f);
+        CDVPluginResult* pluginResult = nil;
+        BOOL wasOpened = [self.controller presentOptionsMenuFromRect:rect inView:cont.view animated:NO];
+
+        if(wasOpened) {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @""];
+        } else {
+            NSDictionary *jsonObj = @{@"status" : @"9",
+                                      @"message" : @"Could not handle UTI"};
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                         messageAsDictionary:jsonObj];
+        }
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     });
 }
 


### PR DESCRIPTION
This is an updated version of keturn's pull request 21 that was never merged, addressing issue #14.  The only changes I've made are to merge in the latest commits from master so that it will merge cleanly.

I'm using Cordova File Transfer Plugin, and passing localFileEntry.toURL() to plugin-file-opener2.
Without keturn's fix, I need to special-case iOS to prevent double-encoding of the URL.
