### PR TITLE
Fix problem with errors not throwing the error callback in windows.

### DIFF
--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -45,14 +45,18 @@
 
 	        getFile(path).then(function (file) {
 	            var options = new Windows.System.LauncherOptions();
-
-	            Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
-	                if (success) {
-	                    successCallback();
-	                } else {
-	                    errorCallback();
-	                }
-	            });
+                try{
+                    Windows.System.Launcher.launchFileAsync(file, options)
+                        .then(function (success) {
+                            if (success) {
+                                successCallback();
+                            } else {
+                                errorCallback();
+                            }
+                        });
+                }catch(e){
+                    errorCallback(e);
+                }
 
 	        }, function (errror) {
 	            console.log("Error abriendo el archivo");


### PR DESCRIPTION
On windows when attempting to open pdf files Windows.System.Launcher.launchFileAsync() is throwing the following error: "The parameter is incorrect"
This error is not running the callback error due to not being caught by the promise handler. Adding a try/catch will solve this and at least allow the error to bubble up to the users code and allow them to debug it easier.
Should at least help with #51 but not fix it.
