### PR TITLE
Fixed for iOS 10

### DIFF
--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -43,7 +43,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     dispatch_async(dispatch_get_main_queue(), ^{
         // TODO: test if this is a URI or a path
-        NSURL *fileURL = [NSURL URLWithString:path];
+        NSURL *fileURL = [NSURL fileURLWithPath:path];
         
         localFile = fileURL.path;
         


### PR DESCRIPTION
Doesnt work on iOS 10, throws exception 

> UIDocumentInteractionController: invalid scheme (null).  Only the file scheme is supported.