### PR TITLE
Update fileOpener2Proxy.js, Windows fixes.

### DIFF
--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -75,7 +75,7 @@
 	        getFile(path).then(function (file) {
 	            var options = new Windows.System.LauncherOptions();
 	            
-	            Windows.System.Launcher.launchFileAsync(file, options).done(function (success) {
+	            Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
 	                successCallback();
 	            }, function (error) {
 	                errorCallback(error);

--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -25,7 +25,7 @@
 
 	    var applicationUri = new Windows.Foundation.Uri(newUri);
 
-	    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);;
+	    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
 	}
 
 	function getFileFromFileUri(uri) {

--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -83,6 +83,7 @@
 
 	        }, function (error) {
 	            console.log("Error while opening the file: "+error);
+		    errorCallback(error);
 	        });
 		}
 		

--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -4,18 +4,46 @@
 
 	var schemes = [
         { protocol: 'ms-app', getFile: getFileFromApplicationUri },
-        { protocol: 'file:///', getFile: getFileFromFileUri }
+        { protocol: 'cdvfile', getFile: getFileFromFileUri }    //protocol cdvfile
 	]
 
-	function getFileFromApplicationUri(uri) {
-	    var applicationUri = new Windows.Foundation.Uri(uri);
+	function nthIndex(str, pat, n) {
+	    var L = str.length, i = -1;
+	    while (n-- && i++ < L) {
+	        i = str.indexOf(pat, i);
+	        if (i < 0) break;
+	    }
+	    return i;
+	}
 
-	    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
+	function getFileFromApplicationUri(uri) {
+	    /* bad path from a file entry due to the last '//' 
+               example: ms-appdata:///local//path/to/file
+            */
+	    var index = nthIndex(uri, "//", 3);
+	    var newUri = uri.substr(0, index) + uri.substr(index + 1);
+
+	    var applicationUri = new Windows.Foundation.Uri(newUri);
+
+	    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);;
 	}
 
 	function getFileFromFileUri(uri) {
-	    var path = Windows.Storage.ApplicationData.current.localFolder.path +
-                        uri.substr(8);
+	    /* uri example:
+               cdvfile://localhost/persistent|temporary|another-fs-root/path/to/file
+            */
+	    var indexFrom = nthIndex(uri, "/", 3) + 1;
+	    var indexTo = nthIndex(uri, "/", 4);
+	    var whichFolder = uri.substring(indexFrom, indexTo);
+	    var filePath = uri.substr(indexTo + 1);
+	    var path = "\\" + filePath;
+
+	    if (whichFolder == "persistent") {
+	        path = Windows.Storage.ApplicationData.current.localFolder.path + path;
+	    }
+	    else {  //temporary, note: no roaming management
+	        path = Windows.Storage.ApplicationData.current.temporaryFolder.path + path;
+	    }
 
 	    return getFileFromNativePath(path);
 	}
@@ -39,23 +67,22 @@
 	module.exports = {
 
 	    open: function (successCallback, errorCallback, args) {
+	        
 	        var path = args[0];
 	        
 	        var getFile = getFileLoaderForScheme(path);
-
+	        
 	        getFile(path).then(function (file) {
 	            var options = new Windows.System.LauncherOptions();
-
-	            Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
-	                if (success) {
-	                    successCallback();
-	                } else {
-	                    errorCallback();
-	                }
+	            
+	            Windows.System.Launcher.launchFileAsync(file, options).done(function (success) {
+	                successCallback();
+	            }, function (error) {
+	                errorCallback(error);
 	            });
 
-	        }, function (errror) {
-	            console.log("Error abriendo el archivo");
+	        }, function (error) {
+	            console.log("Error while opening the file: "+error);
 	        });
 		}
 		


### PR DESCRIPTION
The plugin didn't work on windows, mainly due to uri/path problems (as reported in some issues). I fixed it, + some changes like an error on callback.
