### PR TITLE
Add android support library requirement to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,6 +37,7 @@
           </provider>
         </config-file>
         <source-file src="src/android/res/xml/opener_paths.xml" target-dir="res/xml"/>
+        <framework src="com.android.support:support-v4:+" />
     </platform>
 
     <!-- iOS -->


### PR DESCRIPTION
The android plugin needs the android support library, but this isn't reflected in the plugin.xml. So unless it is imported manually (which can conflict with other plugins) compiling the apk fails.
This change simply imports the dependency .