### PR TITLE
Fixes Android 6 file opening failure.

### DIFF
--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -98,7 +98,7 @@ public class FileOpener2 extends CordovaPlugin {
 			try {
 				Uri path = Uri.fromFile(file);
 				Intent intent = new Intent(Intent.ACTION_VIEW);
-				if(Build.VERSION.SDK_INT >= 24){
+				if(Build.VERSION.SDK_INT >= 23){
 
 					Context context = cordova.getActivity().getApplicationContext();
 					path = FileProvider.getUriForFile(context, cordova.getActivity().getPackageName() + ".opener.provider", file);


### PR DESCRIPTION
I have tested this plugin on Android 6 (SDK 23) and Android 5.1.1. (SDK 22). Android 5.1.1 was always able to open a PDF file. Android 6 failed to open PDF files. Dropping the SDK_INT from 24 to 23 allowed Android 6 to open the PDF files as well.