### PR TITLE
Update opener_paths.xml

### DIFF
--- a/src/android/res/xml/opener_paths.xml
+++ b/src/android/res/xml/opener_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="external_files" path="." />
+    <cache-path name="cached_files" path="." />
 </paths>


### PR DESCRIPTION
Solving issue https://github.com/pwlin/cordova-plugin-file-opener2/issues/102 for cached dir. Probably need to do to all other dir.'s as well (persistent, etc....)