### PR TITLE
Broken APK install for Android 24

### DIFF
--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -98,7 +98,7 @@ public class FileOpener2 extends CordovaPlugin {
 			try {
 				Uri path = Uri.fromFile(file);
 				Intent intent = new Intent(Intent.ACTION_VIEW);
-				if(Build.VERSION.SDK_INT >= 23){
+				if(Build.VERSION.SDK_INT >= 24){
 
 					Context context = cordova.getActivity().getApplicationContext();
 					path = FileProvider.getUriForFile(context, cordova.getActivity().getPackageName() + ".opener.provider", file);


### PR DESCRIPTION
Hi ! I noticed that this commit (https://github.com/pwlin/cordova-plugin-file-opener2/commit/1e64de3cd313281fb3447ed758d5802df85ed829) broke the APK files install on Android 6 instead of fixing it, tested on 2 tablets (nexus and samsung) and a motorola smartphone with stock Android ROMs. 
Would it be possible to revert it for the moment ?

Thanks,

Jeremie A.