### PR TITLE
Fix APK Install on Android 23

### DIFF
--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -98,7 +98,7 @@ public class FileOpener2 extends CordovaPlugin {
 			try {
 				Uri path = Uri.fromFile(file);
 				Intent intent = new Intent(Intent.ACTION_VIEW);
-				if(Build.VERSION.SDK_INT >= 23 && !(contentType.equals("application/vnd.android.package-archive"))){
+				if(Build.VERSION.SDK_INT >= 23 && !(contentType.equals("application/vnd.android.package-archive") && Build.VERSION.SDK_INT == 23)){
 
 					Context context = cordova.getActivity().getApplicationContext();
 					path = FileProvider.getUriForFile(context, cordova.getActivity().getPackageName() + ".opener.provider", file);

--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -98,7 +98,7 @@ public class FileOpener2 extends CordovaPlugin {
 			try {
 				Uri path = Uri.fromFile(file);
 				Intent intent = new Intent(Intent.ACTION_VIEW);
-				if(Build.VERSION.SDK_INT >= 23 && !(contentType.equals("application/vnd.android.package-archive") && Build.VERSION.SDK_INT == 24)){
+				if(Build.VERSION.SDK_INT >= 23 && !(contentType.equals("application/vnd.android.package-archive") && Build.VERSION.SDK_INT == 23)){
 
 					Context context = cordova.getActivity().getApplicationContext();
 					path = FileProvider.getUriForFile(context, cordova.getActivity().getPackageName() + ".opener.provider", file);

--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -98,7 +98,7 @@ public class FileOpener2 extends CordovaPlugin {
 			try {
 				Uri path = Uri.fromFile(file);
 				Intent intent = new Intent(Intent.ACTION_VIEW);
-				if(Build.VERSION.SDK_INT >= 23 && !(contentType.equals("application/vnd.android.package-archive") && Build.VERSION.SDK_INT == 23)){
+				if(Build.VERSION.SDK_INT >= 23 && !(contentType.equals("application/vnd.android.package-archive"))){
 
 					Context context = cordova.getActivity().getApplicationContext();
 					path = FileProvider.getUriForFile(context, cordova.getActivity().getPackageName() + ".opener.provider", file);

--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -98,7 +98,7 @@ public class FileOpener2 extends CordovaPlugin {
 			try {
 				Uri path = Uri.fromFile(file);
 				Intent intent = new Intent(Intent.ACTION_VIEW);
-				if(Build.VERSION.SDK_INT >= 23 && !(contentType.equals("application/vnd.android.package-archive"))){
+				if(Build.VERSION.SDK_INT >= 23 && !contentType.equals("application/vnd.android.package-archive")){
 
 					Context context = cordova.getActivity().getApplicationContext();
 					path = FileProvider.getUriForFile(context, cordova.getActivity().getPackageName() + ".opener.provider", file);

--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -98,7 +98,7 @@ public class FileOpener2 extends CordovaPlugin {
 			try {
 				Uri path = Uri.fromFile(file);
 				Intent intent = new Intent(Intent.ACTION_VIEW);
-				if(Build.VERSION.SDK_INT >= 23){
+				if(Build.VERSION.SDK_INT >= 23 && !(contentType.equals("application/vnd.android.package-archive") && Build.VERSION.SDK_INT == 24)){
 
 					Context context = cordova.getActivity().getApplicationContext();
 					path = FileProvider.getUriForFile(context, cordova.getActivity().getPackageName() + ".opener.provider", file);


### PR DESCRIPTION
Hi ! Since the APK install problem only occurs with this type of files I made this hack, this way only the APK files will be used without a content provider on Android >= 23, and the other ones will work too