### PR TITLE
${applicationId} authority

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-          <provider android:name="io.github.pwlin.cordova.plugins.fileopener2.FileProvider" android:authorities="$PACKAGE_NAME.opener.provider" android:exported="false" android:grantUriPermissions="true">
+          <provider android:name="io.github.pwlin.cordova.plugins.fileopener2.FileProvider" android:authorities="${applicationId}.opener.provider" android:exported="false" android:grantUriPermissions="true">
             <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/opener_paths" />
           </provider>
         </config-file>


### PR DESCRIPTION
Fix for the authority issue discussed here: https://github.com/pwlin/cordova-plugin-file-opener2/issues/130