### PR TITLE
option to force usage of contentType on ios

### DIFF
--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -34,22 +34,32 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 	NSString *contentType = nil;
 	BOOL showPreview = YES;
+	BOOL useContentType = NO;
 
-	if([command.arguments count] == 2) { // Includes contentType
+	if([command.arguments count] >= 2) { // Includes contentType
 		contentType = [command.arguments objectAtIndex:1];
 	}
 
-	if ([command.arguments count] == 3) {
+	if ([command.arguments count] >= 3) {
 		showPreview = [[command.arguments objectAtIndex:2] boolValue];
+	}
+
+	if ([command.arguments count] >= 4) {
+		useContentType = [[command.arguments objectAtIndex:3] boolValue];
 	}
 
 	CDVViewController* cont = (CDVViewController*)[super viewController];
 	self.cdvViewController = cont;
+	NSString *uti = nil;
 
-	NSArray *dotParts = [path componentsSeparatedByString:@"."];
-	NSString *fileExt = [dotParts lastObject];
+	if(useContentType){
+		uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (__bridge CFStringRef)contentType, NULL);
+	} else {
+		NSArray *dotParts = [path componentsSeparatedByString:@"."];
+		NSString *fileExt = [dotParts lastObject];
 
-	NSString *uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+		uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		NSURL *fileURL = [NSURL URLWithString:path];

--- a/www/plugins.FileOpener2.js
+++ b/www/plugins.FileOpener2.js
@@ -36,6 +36,12 @@ FileOpener2.prototype.showOpenWithDialog = function (fileName, contentType, call
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, false]);
 };
 
+FileOpener2.prototype.openWithContentType = function (fileName, contentType, callbackContext) {
+    callbackContext = callbackContext || {};
+    if(typeof contentType !== "string"){ throw new Error("contentType must be a String") }
+    exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, true, true]);
+};
+
 FileOpener2.prototype.uninstall = function (packageId, callbackContext) {
     callbackContext = callbackContext || {};
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'uninstall', [packageId]);


### PR DESCRIPTION
None-breaking change.
The JS API is being extended by a "openWithContentType" call that behaves like "open", just that on iOS it uses the mimetype supplied by the "contentType" argument for creating an UTI instead of the file extension, which can be incorrect or missing.
Fixes #150.