### PR TITLE
iOS: use contentType if provided, otherwise fall back to file extension

### DIFF
--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -31,34 +31,25 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - (void) open: (CDVInvokedUrlCommand*)command {
 
-    NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-	NSString *contentType = nil;
+	NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+	NSString *contentType = [command.arguments objectAtIndex:1];
 	BOOL showPreview = YES;
-	BOOL useContentType = NO;
-
-	if([command.arguments count] >= 2) { // Includes contentType
-		contentType = [command.arguments objectAtIndex:1];
-	}
 
 	if ([command.arguments count] >= 3) {
 		showPreview = [[command.arguments objectAtIndex:2] boolValue];
-	}
-
-	if ([command.arguments count] >= 4) {
-		useContentType = [[command.arguments objectAtIndex:3] boolValue];
 	}
 
 	CDVViewController* cont = (CDVViewController*)[super viewController];
 	self.cdvViewController = cont;
 	NSString *uti = nil;
 
-	if(useContentType){
-		uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (__bridge CFStringRef)contentType, NULL);
-	} else {
+	if([contentType length] == 0){
 		NSArray *dotParts = [path componentsSeparatedByString:@"."];
 		NSString *fileExt = [dotParts lastObject];
 
 		uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+	} else {
+		uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (__bridge CFStringRef)contentType, NULL);
 	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{

--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -34,22 +34,32 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 	NSString *contentType = nil;
 	BOOL showPreview = YES;
+	BOOL useContentType = NO;
 
-	if([command.arguments count] == 2) { // Includes contentType
+	if([command.arguments count] >= 2) { // Includes contentType
 		contentType = [command.arguments objectAtIndex:1];
 	}
 
-	if ([command.arguments count] == 3) {
+	if ([command.arguments count] >= 3) {
 		showPreview = [[command.arguments objectAtIndex:2] boolValue];
+	}
+
+	if ([command.arguments count] >= 4) {
+		useContentType = [[command.arguments objectAtIndex:3] boolValue];
 	}
 
 	CDVViewController* cont = (CDVViewController*)[super viewController];
 	self.cdvViewController = cont;
+	NSString *uti = nil;
 
-	NSArray *dotParts = [path componentsSeparatedByString:@"."];
-	NSString *fileExt = [dotParts lastObject];
+	if(useContentType){
+		uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (__bridge CFStringRef)contentType, NULL);
+	} else {
+		NSArray *dotParts = [path componentsSeparatedByString:@"."];
+		NSString *fileExt = [dotParts lastObject];
 
-	NSString *uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+		uti = (__bridge NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExt, NULL);
+	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		NSURL *fileURL = [NSURL URLWithString:path];

--- a/www/plugins.FileOpener2.js
+++ b/www/plugins.FileOpener2.js
@@ -36,6 +36,12 @@ FileOpener2.prototype.showOpenWithDialog = function (fileName, contentType, call
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, false]);
 };
 
+FileOpener2.prototype.openWithContentType = function (fileName, contentType, callbackContext) {
+    callbackContext = callbackContext || {};
+    if(typeof contentType !== "string"){ throw new Error("contentType must be a String") }
+    exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, true, true]);
+};
+
 FileOpener2.prototype.uninstall = function (packageId, callbackContext) {
     callbackContext = callbackContext || {};
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'uninstall', [packageId]);

--- a/www/plugins.FileOpener2.js
+++ b/www/plugins.FileOpener2.js
@@ -38,12 +38,6 @@ FileOpener2.prototype.showOpenWithDialog = function (fileName, contentType, call
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, false]);
 };
 
-FileOpener2.prototype.openWithContentType = function (fileName, contentType, callbackContext) {
-    callbackContext = callbackContext || {};
-    if(typeof contentType !== "string"){ throw new Error("contentType must be a String") }
-    exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, true, true]);
-};
-
 FileOpener2.prototype.uninstall = function (packageId, callbackContext) {
     callbackContext = callbackContext || {};
     exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'uninstall', [packageId]);


### PR DESCRIPTION
iOS now uses contentType to detect its UTI if provided, and falls back to sniffing the file extension otherwise. This can be useful in cases where there is no file extension, or when the mime type should be forced.
This possibly breaks some setups, since it was possible to supply invalid contentTypes to iOS until now. This was/is not possible on the other platforms either, so this can rather be viewed as converging platform behaviour more than a breaking change.
Fixes #150.