### PR TITLE
Fixed path names in opener_paths.xml

### DIFF
--- a/src/android/res/xml/opener_paths.xml
+++ b/src/android/res/xml/opener_paths.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <files-path name="files" path="." />
-    <external-files-path name="external_files" path="." />
-    <external-path name="external_files" path="." />
-    <cache-path name="cached_files" path="." />
-    <external-cache-path name="cached_files" path="." />
+    <external-files-path name="files-external" path="." />
+    <external-path name="files-external" path="." />
+    <cache-path name="cache" path="." />
+    <external-cache-path name="cache-external" path="." />
 </paths>


### PR DESCRIPTION
Currently when attempting to open a file from the application's cache directory, the plugin seems to be looking in the application's data directory instead. I'm passing a URL like the following to the `FileOpener.open()` method:

`file:///data/user/0/<app-id>/cache/<path-to-file.pdf>`

However the following exception is thrown:

`java.lang.IllegalArgumentException: Failed to find configured root that contains /data/data/<app-id>/cache/<path-to-file.pdf>`

Changing the `cache-path` name in `opener_paths.xml` from "cached_files" to "cache" fixes my issue. I've seen you suggest this fix in another issue and perhaps there's a reason it hasn't been change yet, but it seems like the "name" attributes in this file might need to match the filesystem names outline [here](https://github.com/apache/cordova-plugin-file#configuring-the-plugin-optional)?

If it helps, I'm running Ionic 3 and using the File Opener plugin that wraps this plugin.