### PR TITLE
decode file url with percent escape for android and ios.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@
           </provider>
         </config-file>
         <source-file src="src/android/res/xml/opener_paths.xml" target-dir="res/xml" />
-        <framework src="com.android.support:support-v4:+" />
+        <framework src="com.android.support:support-v4:26.0.0-alpha1" />
     </platform>
 
     <!-- iOS -->

--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -95,7 +95,7 @@ public class FileOpener2 extends CordovaPlugin {
 		try {
 			CordovaResourceApi resourceApi = webView.getResourceApi();
 			Uri fileUri = resourceApi.remapUri(Uri.parse(fileArg));
-			fileName = this.stripFileProtocol(fileUri.toString());
+			fileName = fileUri.getPath();
 		} catch (Exception e) {
 			fileName = fileArg;
 		}
@@ -178,13 +178,5 @@ public class FileOpener2 extends CordovaPlugin {
         return appInstalled;
 	}
 
-	private String stripFileProtocol(String uriString) {
-		if (uriString.startsWith("file://")) {
-			uriString = uriString.substring(7);
-		} else if (uriString.startsWith("content://")) {
-			uriString = uriString.substring(10);
-		}
-		return uriString;
-	}
-
 }
+

--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -31,7 +31,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - (void) open: (CDVInvokedUrlCommand*)command {
 
-	NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+	NSString *path = [[command.arguments objectAtIndex:0] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
 	NSString *contentType = [command.arguments objectAtIndex:1];
 	BOOL showPreview = YES;
 
@@ -53,7 +53,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		NSURL *fileURL = [NSURL URLWithString:path];
+		NSURL *fileURL = [NSURL URLWithString:[path stringByRemovingPercentEncoding]];
 
 		localFile = fileURL.path;
 


### PR DESCRIPTION
Special characters in url are escaped, which would be decoded when converted to path.