### PR TITLE
Specify the static version of the Android framework to avoid build error

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@
           </provider>
         </config-file>
         <source-file src="src/android/res/xml/opener_paths.xml" target-dir="res/xml" />
-        <framework src="com.android.support:support-v4:+" />
+        <framework src="com.android.support:support-v4:27.1.0" />
     </platform>
 
     <!-- iOS -->


### PR DESCRIPTION
Building android platform this error appear:
"ERROR: In <declare-styleable> FontFamilyFont, unable to find attribute android:fontVariationSettings                                                                                            
ERROR: In <declare-styleable> FontFamilyFont, unable to find attribute android:ttcIndex"

With the sign + the android framework used is the new and latest version (28.0.0) but seems incompatible now.

I have fixed writing static version of framework 27.1.0