### PR TITLE
Fix problem with errors not throwing the error callback in windows.

### DIFF
--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -1,95 +1,97 @@
 
-var cordova = require('cordova'),
-    fileOpener2 = require('./FileOpener2');
+    var cordova = require('cordova'),
+        fileOpener2 = require('./FileOpener2');
 
-var schemes = [
-    { protocol: 'ms-app', getFile: getFileFromApplicationUri },
-    { protocol: 'cdvfile', getFile: getFileFromFileUri }    //protocol cdvfile
-]
+    var schemes = [
+        { protocol: 'ms-app', getFile: getFileFromApplicationUri },
+        { protocol: 'cdvfile', getFile: getFileFromFileUri }    //protocol cdvfile
+    ]
 
-function nthIndex(str, pat, n) {
-    var L = str.length, i = -1;
-    while (n-- && i++ < L) {
-        i = str.indexOf(pat, i);
-        if (i < 0) break;
-    }
-    return i;
-}
-
-function getFileFromApplicationUri(uri) {
-    /* bad path from a file entry due to the last '//' 
-           example: ms-appdata:///local//path/to/file
-        */
-    var index = nthIndex(uri, "//", 3);
-    var newUri = uri.substr(0, index) + uri.substr(index + 1);
-
-    var applicationUri = new Windows.Foundation.Uri(newUri);
-
-    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
-}
-
-function getFileFromFileUri(uri) {
-    /* uri example:
-           cdvfile://localhost/persistent|temporary|another-fs-root/path/to/file
-        */
-    var indexFrom = nthIndex(uri, "/", 3) + 1;
-    var indexTo = nthIndex(uri, "/", 4);
-    var whichFolder = uri.substring(indexFrom, indexTo);
-    var filePath = uri.substr(indexTo + 1);
-    var path = "\\" + filePath;
-
-    if (whichFolder == "persistent") {
-        path = Windows.Storage.ApplicationData.current.localFolder.path + path;
-    }
-    else {  //temporary, note: no roaming management
-        path = Windows.Storage.ApplicationData.current.temporaryFolder.path + path;
+    function nthIndex(str, pat, n) {
+        var L = str.length, i = -1;
+        while (n-- && i++ < L) {
+            i = str.indexOf(pat, i);
+            if (i < 0) break;
+        }
+        return i;
     }
 
-    return getFileFromNativePath(path);
-}
+    function getFileFromApplicationUri(uri) {
+        /* bad path from a file entry due to the last '//' 
+               example: ms-appdata:///local//path/to/file
+            */
+        var index = nthIndex(uri, "//", 3);
+        var newUri = uri.substr(0, index) + uri.substr(index + 1);
 
-function getFileFromNativePath(path) {
-    var nativePath = path.split("/").join("\\");
+        var applicationUri = new Windows.Foundation.Uri(newUri);
 
-    return Windows.Storage.StorageFile.getFileFromPathAsync(nativePath);
-}
+        return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
+    }
 
-function getFileLoaderForScheme(path) {
-    var fileLoader = getFileFromNativePath;
+    function getFileFromFileUri(uri) {
+        /* uri example:
+               cdvfile://localhost/persistent|temporary|another-fs-root/path/to/file
+            */
+        var indexFrom = nthIndex(uri, "/", 3) + 1;
+        var indexTo = nthIndex(uri, "/", 4);
+        var whichFolder = uri.substring(indexFrom, indexTo);
+        var filePath = uri.substr(indexTo + 1);
+        var path = "\\" + filePath;
 
-    schemes.some(function (scheme) {
-        return path.indexOf(scheme.protocol) === 0 ? ((fileLoader = scheme.getFile), true) : false;
-    });
+        if (whichFolder == "persistent") {
+            path = Windows.Storage.ApplicationData.current.localFolder.path + path;
+        }
+        else {  //temporary, note: no roaming management
+            path = Windows.Storage.ApplicationData.current.temporaryFolder.path + path;
+        }
 
-    return fileLoader;
-}
+        return getFileFromNativePath(path);
+    }
 
-module.exports = {
+    function getFileFromNativePath(path) {
+        var nativePath = path.split("/").join("\\");
 
-    open: function (successCallback, errorCallback, args) {
-        
-        var path = args[0];
-        
-        var getFile = getFileLoaderForScheme(path);
-        try{
-                getFile(path).then(function (file) {
-                var options = new Windows.System.LauncherOptions();
+        return Windows.Storage.StorageFile.getFileFromPathAsync(nativePath);
+    }
+
+    function getFileLoaderForScheme(path) {
+        var fileLoader = getFileFromNativePath;
+
+        schemes.some(function (scheme) {
+            return path.indexOf(scheme.protocol) === 0 ? ((fileLoader = scheme.getFile), true) : false;
+        });
+
+        return fileLoader;
+    }
+
+    module.exports = {
+
+        open: function (successCallback, errorCallback, args) {
             
-                Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
-                    successCallback();
-                }, function (error) {
+            var path = args[0];
+            
+            var getFile = getFileLoaderForScheme(path);
+            
+            getFile(path).then(function (file) {
+                var options = new Windows.System.LauncherOptions();
+                
+                try{
+                    Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
+                        successCallback();
+                    }, function (error) {
+                        errorCallback(error);
+                    });
+                }catch(error){
                     errorCallback(error);
-                });
+                }
+
             }, function (error) {
                 console.log("Error while opening the file: "+error);
             errorCallback(error);
             });
-        }catch(error){
-                errorCallback(error);
         }
-    }
+        
+    };
 
-};
-
-require("cordova/exec/proxy").add("FileOpener2", module.exports);
+    require("cordova/exec/proxy").add("FileOpener2", module.exports);
 

--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -1,97 +1,97 @@
 
-    var cordova = require('cordova'),
-        fileOpener2 = require('./FileOpener2');
+	var cordova = require('cordova'),
+		fileOpener2 = require('./FileOpener2');
 
-    var schemes = [
+	var schemes = [
         { protocol: 'ms-app', getFile: getFileFromApplicationUri },
         { protocol: 'cdvfile', getFile: getFileFromFileUri }    //protocol cdvfile
-    ]
+	]
 
-    function nthIndex(str, pat, n) {
-        var L = str.length, i = -1;
-        while (n-- && i++ < L) {
-            i = str.indexOf(pat, i);
-            if (i < 0) break;
-        }
-        return i;
-    }
+	function nthIndex(str, pat, n) {
+	    var L = str.length, i = -1;
+	    while (n-- && i++ < L) {
+	        i = str.indexOf(pat, i);
+	        if (i < 0) break;
+	    }
+	    return i;
+	}
 
-    function getFileFromApplicationUri(uri) {
-        /* bad path from a file entry due to the last '//' 
+	function getFileFromApplicationUri(uri) {
+	    /* bad path from a file entry due to the last '//' 
                example: ms-appdata:///local//path/to/file
             */
-        var index = nthIndex(uri, "//", 3);
-        var newUri = uri.substr(0, index) + uri.substr(index + 1);
+	    var index = nthIndex(uri, "//", 3);
+	    var newUri = uri.substr(0, index) + uri.substr(index + 1);
 
-        var applicationUri = new Windows.Foundation.Uri(newUri);
+	    var applicationUri = new Windows.Foundation.Uri(newUri);
 
-        return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
-    }
+	    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
+	}
 
-    function getFileFromFileUri(uri) {
-        /* uri example:
+	function getFileFromFileUri(uri) {
+	    /* uri example:
                cdvfile://localhost/persistent|temporary|another-fs-root/path/to/file
             */
-        var indexFrom = nthIndex(uri, "/", 3) + 1;
-        var indexTo = nthIndex(uri, "/", 4);
-        var whichFolder = uri.substring(indexFrom, indexTo);
-        var filePath = uri.substr(indexTo + 1);
-        var path = "\\" + filePath;
+	    var indexFrom = nthIndex(uri, "/", 3) + 1;
+	    var indexTo = nthIndex(uri, "/", 4);
+	    var whichFolder = uri.substring(indexFrom, indexTo);
+	    var filePath = uri.substr(indexTo + 1);
+	    var path = "\\" + filePath;
 
-        if (whichFolder == "persistent") {
-            path = Windows.Storage.ApplicationData.current.localFolder.path + path;
-        }
-        else {  //temporary, note: no roaming management
-            path = Windows.Storage.ApplicationData.current.temporaryFolder.path + path;
-        }
+	    if (whichFolder == "persistent") {
+	        path = Windows.Storage.ApplicationData.current.localFolder.path + path;
+	    }
+	    else {  //temporary, note: no roaming management
+	        path = Windows.Storage.ApplicationData.current.temporaryFolder.path + path;
+	    }
 
-        return getFileFromNativePath(path);
-    }
+	    return getFileFromNativePath(path);
+	}
 
-    function getFileFromNativePath(path) {
-        var nativePath = path.split("/").join("\\");
+	function getFileFromNativePath(path) {
+	    var nativePath = path.split("/").join("\\");
 
-        return Windows.Storage.StorageFile.getFileFromPathAsync(nativePath);
-    }
+	    return Windows.Storage.StorageFile.getFileFromPathAsync(nativePath);
+	}
 
-    function getFileLoaderForScheme(path) {
-        var fileLoader = getFileFromNativePath;
+	function getFileLoaderForScheme(path) {
+	    var fileLoader = getFileFromNativePath;
 
-        schemes.some(function (scheme) {
-            return path.indexOf(scheme.protocol) === 0 ? ((fileLoader = scheme.getFile), true) : false;
-        });
+	    schemes.some(function (scheme) {
+	        return path.indexOf(scheme.protocol) === 0 ? ((fileLoader = scheme.getFile), true) : false;
+	    });
 
-        return fileLoader;
-    }
+	    return fileLoader;
+	}
 
-    module.exports = {
+	module.exports = {
 
-        open: function (successCallback, errorCallback, args) {
-            
-            var path = args[0];
-            
-            var getFile = getFileLoaderForScheme(path);
-            
-            getFile(path).then(function (file) {
-                var options = new Windows.System.LauncherOptions();
-                
+	    open: function (successCallback, errorCallback, args) {
+	        
+	        var path = args[0];
+	        
+	        var getFile = getFileLoaderForScheme(path);
+	        
+	        getFile(path).then(function (file) {
+	            var options = new Windows.System.LauncherOptions();
+	            
                 try{
-                    Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
-                        successCallback();
-                    }, function (error) {
-                        errorCallback(error);
-                    });
+	                Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
+	                    successCallback();
+	                }, function (error) {
+	                    errorCallback(error);
+	                });
                 }catch(error){
                     errorCallback(error);
                 }
 
-            }, function (error) {
-                console.log("Error while opening the file: "+error);
-            errorCallback(error);
-            });
-        }
-        
-    };
+	        }, function (error) {
+	            console.log("Error while opening the file: "+error);
+		    errorCallback(error);
+	        });
+		}
+		
+	};
 
-    require("cordova/exec/proxy").add("FileOpener2", module.exports);
+	require("cordova/exec/proxy").add("FileOpener2", module.exports);
 

--- a/src/windows/fileOpener2Proxy.js
+++ b/src/windows/fileOpener2Proxy.js
@@ -1,93 +1,95 @@
 
-	var cordova = require('cordova'),
-		fileOpener2 = require('./FileOpener2');
+var cordova = require('cordova'),
+    fileOpener2 = require('./FileOpener2');
 
-	var schemes = [
-        { protocol: 'ms-app', getFile: getFileFromApplicationUri },
-        { protocol: 'cdvfile', getFile: getFileFromFileUri }    //protocol cdvfile
-	]
+var schemes = [
+    { protocol: 'ms-app', getFile: getFileFromApplicationUri },
+    { protocol: 'cdvfile', getFile: getFileFromFileUri }    //protocol cdvfile
+]
 
-	function nthIndex(str, pat, n) {
-	    var L = str.length, i = -1;
-	    while (n-- && i++ < L) {
-	        i = str.indexOf(pat, i);
-	        if (i < 0) break;
-	    }
-	    return i;
-	}
+function nthIndex(str, pat, n) {
+    var L = str.length, i = -1;
+    while (n-- && i++ < L) {
+        i = str.indexOf(pat, i);
+        if (i < 0) break;
+    }
+    return i;
+}
 
-	function getFileFromApplicationUri(uri) {
-	    /* bad path from a file entry due to the last '//' 
-               example: ms-appdata:///local//path/to/file
-            */
-	    var index = nthIndex(uri, "//", 3);
-	    var newUri = uri.substr(0, index) + uri.substr(index + 1);
+function getFileFromApplicationUri(uri) {
+    /* bad path from a file entry due to the last '//' 
+           example: ms-appdata:///local//path/to/file
+        */
+    var index = nthIndex(uri, "//", 3);
+    var newUri = uri.substr(0, index) + uri.substr(index + 1);
 
-	    var applicationUri = new Windows.Foundation.Uri(newUri);
+    var applicationUri = new Windows.Foundation.Uri(newUri);
 
-	    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
-	}
+    return Windows.Storage.StorageFile.getFileFromApplicationUriAsync(applicationUri);
+}
 
-	function getFileFromFileUri(uri) {
-	    /* uri example:
-               cdvfile://localhost/persistent|temporary|another-fs-root/path/to/file
-            */
-	    var indexFrom = nthIndex(uri, "/", 3) + 1;
-	    var indexTo = nthIndex(uri, "/", 4);
-	    var whichFolder = uri.substring(indexFrom, indexTo);
-	    var filePath = uri.substr(indexTo + 1);
-	    var path = "\\" + filePath;
+function getFileFromFileUri(uri) {
+    /* uri example:
+           cdvfile://localhost/persistent|temporary|another-fs-root/path/to/file
+        */
+    var indexFrom = nthIndex(uri, "/", 3) + 1;
+    var indexTo = nthIndex(uri, "/", 4);
+    var whichFolder = uri.substring(indexFrom, indexTo);
+    var filePath = uri.substr(indexTo + 1);
+    var path = "\\" + filePath;
 
-	    if (whichFolder == "persistent") {
-	        path = Windows.Storage.ApplicationData.current.localFolder.path + path;
-	    }
-	    else {  //temporary, note: no roaming management
-	        path = Windows.Storage.ApplicationData.current.temporaryFolder.path + path;
-	    }
+    if (whichFolder == "persistent") {
+        path = Windows.Storage.ApplicationData.current.localFolder.path + path;
+    }
+    else {  //temporary, note: no roaming management
+        path = Windows.Storage.ApplicationData.current.temporaryFolder.path + path;
+    }
 
-	    return getFileFromNativePath(path);
-	}
+    return getFileFromNativePath(path);
+}
 
-	function getFileFromNativePath(path) {
-	    var nativePath = path.split("/").join("\\");
+function getFileFromNativePath(path) {
+    var nativePath = path.split("/").join("\\");
 
-	    return Windows.Storage.StorageFile.getFileFromPathAsync(nativePath);
-	}
+    return Windows.Storage.StorageFile.getFileFromPathAsync(nativePath);
+}
 
-	function getFileLoaderForScheme(path) {
-	    var fileLoader = getFileFromNativePath;
+function getFileLoaderForScheme(path) {
+    var fileLoader = getFileFromNativePath;
 
-	    schemes.some(function (scheme) {
-	        return path.indexOf(scheme.protocol) === 0 ? ((fileLoader = scheme.getFile), true) : false;
-	    });
+    schemes.some(function (scheme) {
+        return path.indexOf(scheme.protocol) === 0 ? ((fileLoader = scheme.getFile), true) : false;
+    });
 
-	    return fileLoader;
-	}
+    return fileLoader;
+}
 
-	module.exports = {
+module.exports = {
 
-	    open: function (successCallback, errorCallback, args) {
-	        
-	        var path = args[0];
-	        
-	        var getFile = getFileLoaderForScheme(path);
-	        
-	        getFile(path).then(function (file) {
-	            var options = new Windows.System.LauncherOptions();
-	            
-	            Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
-	                successCallback();
-	            }, function (error) {
-	                errorCallback(error);
-	            });
+    open: function (successCallback, errorCallback, args) {
+        
+        var path = args[0];
+        
+        var getFile = getFileLoaderForScheme(path);
+        try{
+                getFile(path).then(function (file) {
+                var options = new Windows.System.LauncherOptions();
+            
+                Windows.System.Launcher.launchFileAsync(file, options).then(function (success) {
+                    successCallback();
+                }, function (error) {
+                    errorCallback(error);
+                });
+            }, function (error) {
+                console.log("Error while opening the file: "+error);
+            errorCallback(error);
+            });
+        }catch(error){
+                errorCallback(error);
+        }
+    }
 
-	        }, function (error) {
-	            console.log("Error while opening the file: "+error);
-		    errorCallback(error);
-	        });
-		}
-		
-	};
+};
 
-	require("cordova/exec/proxy").add("FileOpener2", module.exports);
+require("cordova/exec/proxy").add("FileOpener2", module.exports);
 


### PR DESCRIPTION
Had to create a new PR for #52 as I had deleted the fork where the original PR came from.
From the original PR:

> On windows when attempting to open pdf files Windows.System.Launcher.launchFileAsync() is throwing the following error: "The parameter is incorrect"
This error is not running the callback error due to not being caught by the promise handler. Adding a try/catch will solve this and at least allow the error to bubble up to the users code and allow them to debug it easier.
Should at least help with #51 but not fix it.