### PR TITLE
Grant Write permission in android intent

### DIFF
--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileOpener2.java
@@ -121,7 +121,7 @@ public class FileOpener2 extends CordovaPlugin {
 					Context context = cordova.getActivity().getApplicationContext();
 					Uri path = FileProvider.getUriForFile(context, cordova.getActivity().getPackageName() + ".opener.provider", file);
 					intent.setDataAndType(path, contentType);
-					intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_ACTIVITY_NO_HISTORY);
+					intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_ACTIVITY_NO_HISTORY);
 
 				}
 


### PR DESCRIPTION
Added flag Intent.FLAG_GRANT_WRITE_URI_PERMISSION to file opening for android platform, otherwise the program used to open the requested file would not be allowed to save edits.