### PR TITLE
Fix showOpenWithDialog was rendered outside of viewport on iPads

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,12 @@ cordova.plugins.fileOpener2.showOpenWithDialog(
         },
         success : function () {
             console.log('file opened successfully');
-        }
+        },
+        position : [0, 0]
     }
 );
 ```
+`position` array of coordinates from top-left device screen, use for iOS dialog positioning.
 
 ## fileOpener2.uninstall(packageId, callbackContext)
 

--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -31,7 +31,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - (void) open: (CDVInvokedUrlCommand*)command {
 
-    NSString *path = [command.arguments objectAtIndex:0];
+  NSString *path = [command.arguments objectAtIndex:0];
 	NSString *contentType = [command.arguments objectAtIndex:1];
 	BOOL showPreview = YES;
 
@@ -82,13 +82,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		CDVPluginResult* pluginResult = nil;
 
 		//Opens the file preview
+		CGRect rect;
+		if ([command.arguments count] >= 4) {
+			NSArray *positionValues = [command.arguments objectAtIndex:3];
+			rect = CGRectMake(0, 0, [[positionValues objectAtIndex:0] floatValue], [[positionValues objectAtIndex:1] floatValue]);
+		} else {
+			rect = CGRectMake(0, 0, cont.view.bounds.size.width, cont.view.bounds.size.height);
+		}
+
 		BOOL wasOpened = NO;
 
 		if (showPreview) {
 			wasOpened = [docController presentPreviewAnimated: NO];
 		} else {
 			CDVViewController* cont = self.cdvViewController;
-			CGRect rect = CGRectMake(cont.view.bounds.size.width, 0, cont.view.bounds.size.height, 0);
 			wasOpened = [docController presentOpenInMenuFromRect:rect inView:cont.view animated:YES];
 		}
 

--- a/www/plugins.FileOpener2.js
+++ b/www/plugins.FileOpener2.js
@@ -35,7 +35,7 @@ FileOpener2.prototype.open = function (fileName, contentType, callbackContext) {
 FileOpener2.prototype.showOpenWithDialog = function (fileName, contentType, callbackContext) {
     contentType = contentType || '';
     callbackContext = callbackContext || {};
-    exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, false]);
+    exec(callbackContext.success || null, callbackContext.error || null, 'FileOpener2', 'open', [fileName, contentType, false, callbackContext.position]);
 };
 
 FileOpener2.prototype.uninstall = function (packageId, callbackContext) {


### PR DESCRIPTION
This pull request makes the fix for the "invisible" open with dialog on iPads originally implemented by @shnist compatible to the new code structure. The user can set the dialog position now. The issue is described in issue #67 