### PR TITLE
Add second check for position values (iOS)

### DIFF
--- a/src/ios/FileOpener2.m
+++ b/src/ios/FileOpener2.m
@@ -83,7 +83,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 		//Opens the file preview
 		CGRect rect;
-		if ([command.arguments count] >= 4) {
+		if ([command.arguments count] >= 4
+			&& ![[command.arguments objectAtIndex:3] isEqual: [NSNull null]]) {
 			NSArray *positionValues = [command.arguments objectAtIndex:3];
 			rect = CGRectMake(0, 0, [[positionValues objectAtIndex:0] floatValue], [[positionValues objectAtIndex:1] floatValue]);
 		} else {


### PR DESCRIPTION
This PR resolves #295

### What was causing the issue?

#### In `www/plugins.FileOpener2.js`:

When calling `showOpenWithDialog` without an optional callbackContext object, an empty object is set by default in the JS bridge:
```
line 37		callbackContext = callbackContext || {};
```

When the `exec` function is called, the missing position data is then referenced in the arguments array, resulting in an `undefined` value:
```
line 38		[fileName, contentType, false, callbackContext.position]
```

#### In `src/ios/FileOpener2.m`:

The `undefined` data is interpreted as a `NSNull` object and still placed in the array.
![Screen Shot 2020-05-14 at 6 54 39 PM](https://user-images.githubusercontent.com/25131700/81997160-97e37500-9614-11ea-8a2f-81ba616a2dee.png)

On line 86, there is a check for array length, but not a check to see if the object is valid. This means `positionValues` on line 87, which should be a 2 item array, is a `NSNull` object instead. When the expected array items are accessed on line 88, this causes a `NSInvalidArgumentException`.
```
line 86		if ([command.arguments count] >= 4) {
line 87			NSArray *positionValues = [command.arguments objectAtIndex:3];
line 88			rect = CGRectMake(0, 0, [[positionValues objectAtIndex:0] floatValue], [[positionValues objectAtIndex:1] floatValue]);
```

### How does this PR correct this issue?
This PR adds a second check to the if statement on line 86 to make sure the item at index 3 in not `NSNull`.
```
&& ![[command.arguments objectAtIndex:3] isEqual: [NSNull null]]
```