### PR TITLE
Update FileProvider.java

### DIFF
--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileProvider.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileProvider.java
@@ -25,5 +25,5 @@ package io.github.pwlin.cordova.plugins.fileopener2;
 /*
  * http://stackoverflow.com/questions/40746144/error-with-duplicated-fileprovider-in-manifest-xml-with-cordova/41550634#41550634
  */
-public class FileProvider extends android.support.v4.content.FileProvider {
+public class FileProvider extends androidx.core.content.FileProvider {
 }


### PR DESCRIPTION
Using the plugin with ionic capacitor "android.support.v4.content.FileProvider not found" is thrown on compilation. Android Support Libraries are now in the androidx.* package hierarchy. See https://stackoverflow.com/questions/48534293/android-support-v4-content-fileprovider-not-found