### PR TITLE
Modified to AndroidX package

### DIFF
--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileProvider.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileProvider.java
@@ -25,5 +25,5 @@ package io.github.pwlin.cordova.plugins.fileopener2;
 /*
  * http://stackoverflow.com/questions/40746144/error-with-duplicated-fileprovider-in-manifest-xml-with-cordova/41550634#41550634
  */
-public class FileProvider extends android.support.v4.content.FileProvider {
+public class FileProvider extends androidx.core.content.FileProvider {
 }


### PR DESCRIPTION
After migrating to AndroidX, android.support.v4.content.FileProvider cannot be found.