### PR TITLE
fix(#329): removed 'REQUEST_INSTALL_PACKAGES' android permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,6 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider android:name="io.github.pwlin.cordova.plugins.fileopener2.FileProvider" android:authorities="${applicationId}.fileOpener2.provider" android:exported="false" android:grantUriPermissions="true">


### PR DESCRIPTION
Fixes issue #329.

If your application needs this permission because of some requirement, you must add this permission from your application config.xml as the plugin's README says.

https://github.com/pwlin/cordova-plugin-file-opener2#android-apk-installation-limitation