### PR TITLE
Combined changes to fix FileProvider.java (AndroidX) and remove REQUEST_INSTALL_PACKAGES permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,6 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider android:name="io.github.pwlin.cordova.plugins.fileopener2.FileProvider" android:authorities="${applicationId}.fileOpener2.provider" android:exported="false" android:grantUriPermissions="true">

--- a/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileProvider.java
+++ b/src/android/io/github/pwlin/cordova/plugins/fileopener2/FileProvider.java
@@ -25,5 +25,5 @@ package io.github.pwlin.cordova.plugins.fileopener2;
 /*
  * http://stackoverflow.com/questions/40746144/error-with-duplicated-fileprovider-in-manifest-xml-with-cordova/41550634#41550634
  */
-public class FileProvider extends android.support.v4.content.FileProvider {
+public class FileProvider extends androidx.core.content.FileProvider {
 }


### PR DESCRIPTION
For my own app I had to fix both FileProvider and remove REQUEST_INSTALL_PACKAGES to be compliant with Google new policy.

Fix #326 and #329. Same as #333, #332, #330, #318 and #312 but **combined**.